### PR TITLE
initial support for subscribing to many events

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
     - curl -o- https://raw.githubusercontent.com/creationix/nvm/master/install.sh | bash
     - source ~/.nvm/nvm.sh
     - nvm install node
-    - npm install -g webpack yarn
+    - npm install -g webpack@1.14.0 yarn
     - npm install -g eslint babel-eslint eslint-plugin-react
     - eslint bowtie/src/*.js*
     - sudo apt-get update

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
     - "2.7"
     - "3.4"
     - "3.5"
+    - "3.6"
 
 install:
     # get latest version of node

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ python:
     - "2.7"
     - "3.4"
     - "3.5"
-    - "3.6"
 
 install:
     # get latest version of node

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@ test:
 lint:
 	py.test --pylint -m pylint --pylint-rcfile=pylintrc --pylint-error-types=RCWEF --ignore=doc
 
+eslint:
+	eslint bowtie/src/*.js*
+
 coverage:
 	py.test --cov=./ --cov-report html --ignore=doc
 

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@ all: test
 test:
 	py.test --cov=./ --pylint --pylint-rcfile=pylintrc --pylint-error-types=RCWEF --ignore=doc
 
+unit:
+	py.test --cov=./
+
 lint:
 	py.test --pylint -m pylint --pylint-rcfile=pylintrc --pylint-error-types=RCWEF --ignore=doc
 

--- a/bowtie/__init__.py
+++ b/bowtie/__init__.py
@@ -2,7 +2,7 @@
 Bowtie
 """
 
-__version__ = '0.1.0'
+__version__ = '0.2.0-dev'
 
 from bowtie._layout import Layout
 from bowtie._command import command

--- a/bowtie/_command.py
+++ b/bowtie/_command.py
@@ -9,13 +9,16 @@ https://gist.github.com/carlsmith/800cbe3e11f630ac8aa0
 
 import sys
 import inspect
-from bowtie._compat import numargs
 from subprocess import call
 
 import click
 
+from bowtie._compat import numargs
+
 
 class WrongNumberOfArguments(TypeError):
+    """The "build" function accepts an incorrect number of arguments.
+    """
     pass
 
 

--- a/bowtie/_command.py
+++ b/bowtie/_command.py
@@ -9,9 +9,14 @@ https://gist.github.com/carlsmith/800cbe3e11f630ac8aa0
 
 import sys
 import inspect
+from bowtie._compat import numargs
 from subprocess import call
 
 import click
+
+
+class WrongNumberOfArguments(TypeError):
+    pass
 
 
 def command(func):
@@ -38,10 +43,16 @@ def command(func):
         """
         Writes the app, downloads the packages, and bundles it with Webpack.
         """
-        try:
-            func(ctx.obj)
-        except TypeError:
+        nargs = numargs(func)
+        if nargs == 0:
             func()
+        elif nargs == 1:
+            func(ctx.obj)
+        else:
+            raise WrongNumberOfArguments(
+                'Function "{}" should have 0 or 1 argument, it has {}.'
+                .format(func.__name__, nargs)
+            )
 
     @cmd.command(context_settings=dict(ignore_unknown_options=True),
                  add_help_option=False)

--- a/bowtie/_compat.py
+++ b/bowtie/_compat.py
@@ -3,6 +3,7 @@
 python 2/3 compatability
 """
 
+import inspect
 import sys
 from os import makedirs
 
@@ -18,3 +19,31 @@ if IS_PY2:
         except OSError:
             if not exist_ok:
                 raise
+
+def numargs(func):
+    return len(inspect.signature(func).parameters)
+
+if IS_PY2:
+    # pylint: disable=function-redefined,missing-docstring
+    def numargs(func):
+        return sum(map(len, inspect.getargspec(func)[:2]))
+
+# def var_name(x):
+#     gen = globals().items()
+#     # print(globals())
+#     for k, v in gen:
+#         print(k)
+#         if x is v:
+#             return k
+
+
+# def varname(var):
+#     import inspect
+#     frame = inspect.stack()[0][0].f_globals
+#     var_id = id(var)
+#     for name in frame.f_back.f_locals.keys():
+#         try:
+#             if id(eval(name)) == var_id:
+#                 return(name)
+#         except:
+#             pass

--- a/bowtie/_compat.py
+++ b/bowtie/_compat.py
@@ -21,29 +21,14 @@ if IS_PY2:
                 raise
 
 def numargs(func):
+    """Gets number of arguments in python 3.
+    """
     return len(inspect.signature(func).parameters)
 
 if IS_PY2:
-    # pylint: disable=function-redefined,missing-docstring
+    # pylint: disable=function-redefined
     def numargs(func):
+        """Gets number of arguments in python 2.
+        """
+        # pylint: disable=deprecated-method
         return sum(map(len, inspect.getargspec(func)[:2]))
-
-# def var_name(x):
-#     gen = globals().items()
-#     # print(globals())
-#     for k, v in gen:
-#         print(k)
-#         if x is v:
-#             return k
-
-
-# def varname(var):
-#     import inspect
-#     frame = inspect.stack()[0][0].f_globals
-#     var_id = id(var)
-#     for name in frame.f_back.f_locals.keys():
-#         try:
-#             if id(eval(name)) == var_id:
-#                 return(name)
-#         except:
-#             pass

--- a/bowtie/_component.py
+++ b/bowtie/_component.py
@@ -6,10 +6,10 @@ Bowtie Component classes, all visual and control components inherit these
 # need this for get commands on python2
 from __future__ import unicode_literals
 
-
 # pylint: disable=redefined-builtin
 from builtins import bytes
 
+import inspect
 from functools import wraps
 import json
 from datetime import datetime, date, time
@@ -20,6 +20,13 @@ from flask_socketio import emit
 from future.utils import with_metaclass
 import eventlet
 from eventlet.queue import LightQueue
+
+
+def varname(variable):
+    locs = inspect.stack()[-1][0].f_locals
+    for name, var in locs.items():
+        if variable is var:
+            return name
 
 
 def json_conversion(obj):
@@ -110,7 +117,15 @@ def make_event(event):
     def actualevent(self):
         name = event.__name__[3:]
         # pylint: disable=protected-access
-        return '{uuid}#{event}'.format(uuid=self._uuid, event=name)
+        ename = '{uuid}#{event}'.format(uuid=self._uuid, event=name)
+        objname = varname(self)
+        try:
+            # the getter post processing function
+            # is preserved with an underscore
+            getter = event(self).__name__
+        except AttributeError:
+            getter = None
+        return ename, objname, getter
 
     return actualevent
 
@@ -186,14 +201,17 @@ def is_getter(attribute):
 
 class _Maker(type):
     def __new__(mcs, name, parents, dct):
-        for k in dct:
+        for k in list(dct.keys()):
             if is_event(k):
                 dct[k] = make_event(dct[k])
             if is_command(k):
                 dct[k] = make_command(dct[k])
             if is_getter(k):
+                # preserve the post-processor with an underscore
+                dct['_' + k] = dct[k]
                 dct[k] = make_getter(dct[k])
         return super(_Maker, mcs).__new__(mcs, name, parents, dct)
+
 
 # pylint: disable=too-few-public-methods
 class Component(with_metaclass(_Maker, object)):

--- a/bowtie/_component.py
+++ b/bowtie/_component.py
@@ -23,6 +23,8 @@ from eventlet.queue import LightQueue
 
 
 def varname(variable):
+    """Returns the name of the given variable.
+    """
     locs = inspect.stack()[-1][0].f_locals
     for name, var in locs.items():
         if variable is var:

--- a/bowtie/_component.py
+++ b/bowtie/_component.py
@@ -25,8 +25,11 @@ from eventlet.queue import LightQueue
 def varname(variable):
     """Returns the name of the given variable.
     """
-    locs = inspect.stack()[-1][0].f_locals
-    for name, var in locs.items():
+    frame = inspect.stack()[2][0]
+    for name, var in frame.f_locals.items():
+        if variable is var:
+            return name
+    for name, var in frame.f_globals.items():
         if variable is var:
             return name
 

--- a/bowtie/_layout.py
+++ b/bowtie/_layout.py
@@ -275,7 +275,7 @@ class Layout(object):
             raise YarnError('Error running "yarn init -y"')
         self.packages.discard(None)
         packages = ' '.join(self._packages + list(self.packages))
-        install = Popen('yarn add --prefer-offline {}'.format(packages),
+        install = Popen('yarn add {}'.format(packages),
                         shell=True, cwd=self.directory).wait()
         if install > 1:
             raise YarnError('Error install node packages')

--- a/bowtie/_layout.py
+++ b/bowtie/_layout.py
@@ -3,6 +3,8 @@
 Defines the Layout class.
 """
 
+from __future__ import print_function
+
 import os
 from os import path
 import inspect

--- a/bowtie/_layout.py
+++ b/bowtie/_layout.py
@@ -275,7 +275,7 @@ class Layout(object):
             raise YarnError('Error running "yarn init -y"')
         self.packages.discard(None)
         packages = ' '.join(self._packages + list(self.packages))
-        install = Popen('yarn add --offline {}'.format(packages),
+        install = Popen('yarn add --prefer-offline {}'.format(packages),
                         shell=True, cwd=self.directory).wait()
         if install > 1:
             raise YarnError('Error install node packages')

--- a/bowtie/_layout.py
+++ b/bowtie/_layout.py
@@ -172,8 +172,6 @@ class Layout(object):
         *events : Each is an event, optional
             Additional events.
         """
-        # print(event)
-
         all_events = [event]
         all_events.extend(events)
 
@@ -226,7 +224,6 @@ class Layout(object):
         server_path = path.join(src, server.name)
         # [1] grabs the parent stack and [1] grabs the filename
         source_filename = inspect.stack()[1][1]
-        # print(self.subscriptions)
         with open(server_path, 'w') as f:
             f.write(
                 server.render(

--- a/bowtie/_layout.py
+++ b/bowtie/_layout.py
@@ -177,9 +177,9 @@ class Layout(object):
         all_events = [event]
         all_events.extend(events)
 
-        for ev in all_events:
+        for evt in all_events:
             # quoted = "'{}'".format(ev)
-            self.subscriptions[ev].append((all_events, func.__name__))
+            self.subscriptions[evt].append((all_events, func.__name__))
 
     def load(self, func):
         """Call a function on load.

--- a/bowtie/control.py
+++ b/bowtie/control.py
@@ -387,9 +387,7 @@ class Number(_Controller):
             Name of event.
 
         """
-        return get
-
-    # _on_change = get
+        return self.get
 
     # pylint: disable=no-self-use
     def get(self, data):

--- a/bowtie/control.py
+++ b/bowtie/control.py
@@ -90,7 +90,6 @@ class DropDown(_Controller):
             'uuid={{{uuid}}} '
             '/>')
 
-
     def __init__(self, labels=None, values=None, multi=False, caption=''):
         super(DropDown, self).__init__()
 
@@ -113,7 +112,7 @@ class DropDown(_Controller):
         | **Payload:** ``dict`` with keys "value" and "label".
 
         """
-        pass
+        return self.get
 
     # pylint: disable=no-self-use
     def do_options(self, labels, values):
@@ -329,6 +328,82 @@ class RangePicker(_DatePickers):
         return data
 
 
+class Number(_Controller):
+    """Create a number input.
+
+    Parameters
+    ----------
+    start : number, optional
+        Starting number
+    minimum : number, optional
+        Lower bound
+    maximum : number, optional
+        Upper bound
+    size : 'default', 'large', 'small', optional
+        Size of the textbox.
+    caption : str, optional
+        Heading text.
+
+    References
+    ----------
+    https://ant.design/components/input/
+
+    """
+    _TEMPLATE = 'number.jsx'
+    _COMPONENT = 'AntNumber'
+    _PACKAGE = 'antd'
+    _TAG = ('<AntNumber '
+            'start={{{start}}} '
+            'min={{{minimum}}} '
+            'max={{{maximum}}} '
+            'step={{{step}}} '
+            'size={{{size}}} '
+            'socket={{socket}} '
+            'uuid={{{uuid}}} '
+            '/>')
+
+    def __init__(self, start=0, minimum=-1e100, maximum=1e100,
+                 step=1, size='default', caption=''):
+        super(Number, self).__init__()
+
+        self._instantiate = self._TAG.format(
+            uuid="'{}'".format(self._uuid),
+            start=start,
+            minimum=minimum,
+            maximum=maximum,
+            step=step,
+            size="'{}'".format(size)
+        )
+        self.caption = caption
+
+    def on_change(self):
+        """Emits an event when the number is changed.
+
+        | **Payload:** ``number``
+
+        Returns
+        -------
+        str
+            Name of event.
+
+        """
+        return get
+
+    # _on_change = get
+
+    # pylint: disable=no-self-use
+    def get(self, data):
+        """
+        Gets the current number.
+
+        Returns
+        -------
+        number
+
+        """
+        return data
+
+
 class Textbox(_Controller):
     """Create a textbox.
 
@@ -475,7 +550,7 @@ class Slider(_Controller):
             Name of event.
 
         """
-        pass
+        return self.get
 
     def on_after_change(self):
         """Emits an event when the slider control is released.
@@ -488,7 +563,7 @@ class Slider(_Controller):
             Name of event.
 
         """
-        pass
+        return self.get
 
     # pylint: disable=no-self-use
     def get(self, data):

--- a/bowtie/control.py
+++ b/bowtie/control.py
@@ -170,7 +170,7 @@ class Switch(_Controller):
             Name of event.
 
         """
-        pass
+        return self.get
 
     # pylint: disable=no-self-use
     def get(self, data):
@@ -235,7 +235,7 @@ class DatePicker(_DatePickers):
             Name of event.
 
         """
-        pass
+        return self.get
 
     # pylint: disable=no-self-use
     def get(self, data):
@@ -274,7 +274,7 @@ class MonthPicker(_DatePickers):
             Name of event.
 
         """
-        pass
+        return self.get
 
     # pylint: disable=no-self-use
     def get(self, data):
@@ -313,7 +313,7 @@ class RangePicker(_DatePickers):
             Name of event.
 
         """
-        pass
+        return self.get
 
     # pylint: disable=no-self-use
     def get(self, data):
@@ -450,7 +450,7 @@ class Textbox(_Controller):
             Name of event.
 
         """
-        pass
+        return self.get
 
     def on_change(self):
         """Emits an event when the text is changed.
@@ -463,7 +463,7 @@ class Textbox(_Controller):
             Name of event.
 
         """
-        pass
+        return self.get
 
     # pylint: disable=no-self-use
     def get(self, data):
@@ -637,7 +637,7 @@ class Nouislider(_Controller):
             Name of event.
 
         """
-        pass
+        return self.get
 
     def on_slide(self):
         """Emits an event when the slider is moved.
@@ -652,7 +652,7 @@ class Nouislider(_Controller):
             Name of event.
 
         """
-        pass
+        return self.get
 
     def on_set(self):
         """Emits an event when the slider is moved.
@@ -667,7 +667,7 @@ class Nouislider(_Controller):
             Name of event.
 
         """
-        pass
+        return self.get
 
     def on_change(self):
         """Emits an event when the slider is moved.
@@ -682,7 +682,7 @@ class Nouislider(_Controller):
             Name of event.
 
         """
-        pass
+        return self.get
 
     def on_start(self):
         """Emits an event when the slider is moved.
@@ -697,7 +697,7 @@ class Nouislider(_Controller):
             Name of event.
 
         """
-        pass
+        return self.get
 
     def on_end(self):
         """Emits an event when the slider is moved.
@@ -712,7 +712,7 @@ class Nouislider(_Controller):
             Name of event.
 
         """
-        pass
+        return self.get
 
     # pylint: disable=no-self-use
     def get(self, data):

--- a/bowtie/src/number.jsx
+++ b/bowtie/src/number.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { InputNumber } from 'antd';
+import 'antd/dist/antd.css';
+
+var msgpack = require('msgpack-lite');
+
+export default class AntNumber extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {value: this.props.start};
+    }
+
+    componentDidMount() {
+        var uuid = this.props.uuid;
+        var socket = this.props.socket;
+        socket.on(uuid + '#get', this.getValue);
+    }
+
+    getValue = (data, fn) => {
+        fn(msgpack.encode(this.state.value));
+    }
+
+    // onChange = value => {
+    //     this.setState({value: value.target.value});
+    //     this.props.socket.emit(this.props.uuid + '#change', msgpack.encode(value.target.value));
+    // }
+    onChange = value => {
+        this.setState({value: value});
+        this.props.socket.emit(this.props.uuid + '#change', msgpack.encode(value));
+    }
+
+    render() {
+        return (
+            <InputNumber
+                min={this.props.min}
+                max={this.props.max}
+                value={this.state.value}
+                onChange={this.onChange}
+                size={this.props.size}
+            />
+        );
+    }
+}
+
+AntNumber.propTypes = {
+    uuid: React.PropTypes.string.isRequired,
+    socket: React.PropTypes.object.isRequired,
+    min: React.PropTypes.number.isRequired,
+    max: React.PropTypes.number.isRequired,
+    start: React.PropTypes.number.isRequired,
+    size: React.PropTypes.string.isRequired,
+};

--- a/bowtie/src/plotly.jsx
+++ b/bowtie/src/plotly.jsx
@@ -35,7 +35,8 @@ export default class PlotlyPlot extends React.Component {
     setClick = data => {
         var p0 = data.points[0];
         var datum = {
-            n: p0.pointNumber,
+            curve: p0.curveNumber,
+            point: p0.pointNumber,
             x: p0.x,
             y: p0.y,
             hover: p0.data.text[p0.pointNumber]
@@ -51,7 +52,8 @@ export default class PlotlyPlot extends React.Component {
     setHover = data => {
         var p0 = data.points[0];
         var datum = {
-            n: p0.pointNumber,
+            curve: p0.curveNumber,
+            point: p0.pointNumber,
             x: p0.x,
             y: p0.y,
             hover: p0.data.text[p0.pointNumber]

--- a/bowtie/src/plotly.jsx
+++ b/bowtie/src/plotly.jsx
@@ -73,7 +73,7 @@ export default class PlotlyPlot extends React.Component {
         // this.container.on('plotly_unhover', function (data) {
         this.container.on('plotly_selected', this.setSelection);
         this.container.on('plotly_click', this.setClick);
-        this.container.on('plotly_hover', this.setClick);
+        this.container.on('plotly_hover', this.setHover);
     }
 
     componentDidMount() {

--- a/bowtie/src/plotly.jsx
+++ b/bowtie/src/plotly.jsx
@@ -49,10 +49,17 @@ export default class PlotlyPlot extends React.Component {
         // this.container.on('plotly_beforehover', function (data) {
         //     socket.emit(uuid + '#beforehover', data);
         // });
-        // // if (this.props.onHover)
-        // this.container.on('plotly_hover', function (data) {
-        //     socket.emit(uuid + '#hover', data);
-        // });
+        this.container.on('plotly_hover', function (data) {
+            var p0 = data.points[0];
+            var datum = {
+                n: p0.pointNumber,
+                x: p0.x,
+                y: p0.y,
+                hover: p0.data.text[p0.pointNumber]
+            };
+            socket.emit(uuid + '#hover', msgpack.encode(datum));
+        });
+
         // // if (this.props.onUnHover)
         // this.container.on('plotly_unhover', function (data) {
         //     socket.emit(uuid + '#unhover', data);

--- a/bowtie/src/plotly.jsx
+++ b/bowtie/src/plotly.jsx
@@ -116,6 +116,9 @@ export default class PlotlyPlot extends React.Component {
     componentWillUnmount() {
         this.props.socket.off(this.props.uuid + '#all');
         this.props.socket.off(this.props.uuid + '#get');
+        this.props.socket.off(this.props.uuid + '#get_select');
+        this.props.socket.off(this.props.uuid + '#get_click');
+        this.props.socket.off(this.props.uuid + '#get_hover');
         Plotly.purge(this.container);
     }
 

--- a/bowtie/src/plotly.jsx
+++ b/bowtie/src/plotly.jsx
@@ -9,6 +9,8 @@ export default class PlotlyPlot extends React.Component {
     constructor(props) {
         super(props);
         this.selection = null;
+        this.click = null;
+        this.hover = null;
         this.state = this.props.initState;
         this.resize = this.resize.bind(this);
         this.props.socket.on(this.props.uuid + '#all', (data) => {
@@ -16,6 +18,9 @@ export default class PlotlyPlot extends React.Component {
             this.setState(msgpack.decode(arr));
         });
         this.props.socket.on(this.props.uuid + '#get', this.getSelection);
+        this.props.socket.on(this.props.uuid + '#get_select', this.getSelection);
+        this.props.socket.on(this.props.uuid + '#get_click', this.getClick);
+        this.props.socket.on(this.props.uuid + '#get_hover', this.getHover);
     }
 
     setSelection = data => {
@@ -27,45 +32,48 @@ export default class PlotlyPlot extends React.Component {
         fn(msgpack.encode(this.selection));
     }
 
+    setClick = data => {
+        var p0 = data.points[0];
+        var datum = {
+            n: p0.pointNumber,
+            x: p0.x,
+            y: p0.y,
+            hover: p0.data.text[p0.pointNumber]
+        };
+        this.click = datum;
+        this.props.socket.emit(this.props.uuid + '#click', msgpack.encode(datum));
+    }
+
+    getClick = (data, fn) => {
+        fn(msgpack.encode(this.click));
+    }
+
+    setHover = data => {
+        var p0 = data.points[0];
+        var datum = {
+            n: p0.pointNumber,
+            x: p0.x,
+            y: p0.y,
+            hover: p0.data.text[p0.pointNumber]
+        };
+        this.hover = datum;
+        this.props.socket.emit(this.props.uuid + '#hover', msgpack.encode(datum));
+    }
+
+    getHover = (data, fn) => {
+        fn(msgpack.encode(this.hover));
+    }
+
     resize() {
         Plotly.Plots.resize(this.container);
     }
 
     addListeners() {
-        var uuid = this.props.uuid;
-        var socket = this.props.socket;
-
-        this.container.on('plotly_click', function (data) {
-            var p0 = data.points[0];
-            var datum = {
-                n: p0.pointNumber,
-                x: p0.x,
-                y: p0.y,
-                hover: p0.data.text[p0.pointNumber]
-            };
-            socket.emit(uuid + '#click', msgpack.encode(datum));
-        });
-        // if (this.props.onBeforeHover)
         // this.container.on('plotly_beforehover', function (data) {
-        //     socket.emit(uuid + '#beforehover', data);
-        // });
-        this.container.on('plotly_hover', function (data) {
-            var p0 = data.points[0];
-            var datum = {
-                n: p0.pointNumber,
-                x: p0.x,
-                y: p0.y,
-                hover: p0.data.text[p0.pointNumber]
-            };
-            socket.emit(uuid + '#hover', msgpack.encode(datum));
-        });
-
-        // // if (this.props.onUnHover)
         // this.container.on('plotly_unhover', function (data) {
-        //     socket.emit(uuid + '#unhover', data);
-        // });
-        // if (this.props.onSelected)
         this.container.on('plotly_selected', this.setSelection);
+        this.container.on('plotly_click', this.setClick);
+        this.container.on('plotly_hover', this.setClick);
     }
 
     componentDidMount() {

--- a/bowtie/templates/server.py
+++ b/bowtie/templates/server.py
@@ -151,8 +151,8 @@ def _(*args):
         {% endif %}
 
         {% for support in supports %}
-            {% if post is not none %}
         user_args = []
+            {% if post is not none %}
                 {% for ev in support[0] %}
         user_args.append(event_data['{{ ev[0] }}'])
                 {% endfor %}

--- a/bowtie/templates/server.py
+++ b/bowtie/templates/server.py
@@ -15,6 +15,10 @@ from flask_socketio import SocketIO, emit
 import eventlet
 
 
+class GetterNotDefined(AttributeError):
+    pass
+
+
 def check_auth(username, password):
     """This function is called to check if a username /
     password combination is valid.
@@ -45,6 +49,8 @@ import {{source_module}}
 app = Flask(__name__)
 app.debug = {{ debug|default(False) }}
 socketio = SocketIO(app, binary=True)
+# not sure if this is secure or how much it matters
+app.secret_key = os.urandom(256)
 
 def context(func):
     def foo():
@@ -106,13 +112,57 @@ def _():
 {% endif %}
 
 
-{% for event, functions in subscriptions.items() %}
-@socketio.on({{ event }})
+{#
+# {% for event, functions in subscriptions.items() %}
+# @socketio.on({{ event }})
+# def _(*args):
+#     {% for func in functions %}
+#     foo = copy_current_request_context({{ source_module }}.{{ func }})
+#     eventlet.spawn(foo, *(msgpack.unpackb(bytes(a['data']), encoding='utf8') for a in args))
+#     {% endfor %}
+# {% endfor %}
+    #}
+
+{# {% for event, (events, functions) in subscriptions.items() %} #}
+{% for event, supports in subscriptions.items() %}
+@socketio.on('{{ event[0] }}')
 def _(*args):
-    {% for func in functions %}
-    foo = copy_current_request_context({{ source_module }}.{{ func }})
-    eventlet.spawn(foo, *(msgpack.unpackb(bytes(a['data']), encoding='utf8') for a in args))
-    {% endfor %}
+    def wrapuser():
+        uniq_events = set()
+        {% for support in supports %}
+        uniq_events.update({{ support[0] }})
+        {% endfor %}
+        uniq_events.remove({{ event }})
+        {% set post = event[2] %}
+        event_data = {}
+        for ev in uniq_events:
+            comp = getattr({{ source_module }}, ev[1])
+            if ev[2] is None:
+                ename = ev[0]
+                raise GetterNotDefined('{ctype} has no getter associated with event "on_{ename}"'
+                                       .format(ctype=type(comp), ename=ename[ename.find('#') + 1:]))
+            getter = getattr(comp, ev[2])
+            event_data[ev[0]] = getter()
+
+        {% if post is not none %}
+        event_data['{{ event[0] }}'] = {{ source_module }}.{{event[1]}}.{{ '_' ~ post }}(
+            msgpack.unpackb(bytes(args[0]['data']), encoding='utf8')
+        )
+        {% endif %}
+
+        {% for support in supports %}
+            {% if post is not none %}
+        user_args = []
+                {% for ev in support[0] %}
+        user_args.append(event_data['{{ ev[0] }}'])
+                {% endfor %}
+            {% endif %}
+        {{ source_module }}.{{ support[1] }}(*user_args)
+        {% endfor %}
+
+    foo = copy_current_request_context(wrapuser)
+    eventlet.spawn(foo)
+
 {% endfor %}
 
 @click.command()

--- a/bowtie/tests/test_compile.py
+++ b/bowtie/tests/test_compile.py
@@ -29,5 +29,5 @@ def test_build(remove_build):
     layout = Layout(directory=path)
     layout.add_controller(ctrl)
     layout.add_visual(viz)
-    layout.subscribe(ctrl.on_change, callback)
+    layout.subscribe(callback, ctrl.on_change)
     layout.build()

--- a/bowtie/tests/test_plotly.py
+++ b/bowtie/tests/test_plotly.py
@@ -33,7 +33,7 @@ def test_plotly(remove_build):
     layout = Layout(directory=path)
     layout.add_visual(viz)
     layout.add_controller(ctrl)
-    layout.subscribe(ctrl.on_change, callback)
+    layout.subscribe(callback, ctrl.on_change)
     layout.build()
 
     env = os.environ

--- a/bowtie/tests/test_plotly.py
+++ b/bowtie/tests/test_plotly.py
@@ -11,8 +11,9 @@ from selenium.webdriver import PhantomJS
 # from selenium.webdriver import ActionChains
 
 from bowtie import Layout
-from bowtie.control import Nouislider
+from bowtie.control import Nouislider, Button
 from bowtie.visual import Plotly
+
 
 
 def callback(*args):
@@ -28,12 +29,15 @@ def test_plotly(remove_build):
     """
     viz = Plotly()
     ctrl = Nouislider()
+    ctrl2 = Button()
 
     path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'build')
     layout = Layout(directory=path)
     layout.add_visual(viz)
     layout.add_controller(ctrl)
+    layout.add_controller(ctrl2)
     layout.subscribe(callback, ctrl.on_change)
+    layout.subscribe(callback, ctrl2.on_click)
     layout.build()
 
     env = os.environ

--- a/bowtie/visual.py
+++ b/bowtie/visual.py
@@ -278,7 +278,7 @@ class Plotly(_Visual):
             Name of event.
 
         """
-        return self.get
+        return self.get_click
 
     def on_beforehover(self):
         """Emits an event before hovering over a point.
@@ -291,7 +291,7 @@ class Plotly(_Visual):
             Name of event.
 
         """
-        pass
+        return self.get_hover
 
     def on_hover(self):
         """Emits an event after hovering over a point.
@@ -304,7 +304,7 @@ class Plotly(_Visual):
             Name of event.
 
         """
-        pass
+        return self.get_hover
 
     def on_unhover(self):
         """Emits an event when hover is removed.
@@ -317,7 +317,7 @@ class Plotly(_Visual):
             Name of event.
 
         """
-        pass
+        return self.get_hover
 
     def on_select(self):
         """Emits an event when points are selected with a tool.
@@ -330,7 +330,7 @@ class Plotly(_Visual):
             Name of event.
 
         """
-        return self.get
+        return self.get_select
 
     ## Commands
 
@@ -396,6 +396,36 @@ class Plotly(_Visual):
         return config
 
     def get(self, data):
+        """
+        Gets the current selection of points.
+
+        Returns
+        -------
+        list
+        """
+        return data
+
+    def get_select(self, data):
+        """
+        Gets the current selection of points.
+
+        Returns
+        -------
+        list
+        """
+        return data
+
+    def get_click(self, data):
+        """
+        Gets the current selection of points.
+
+        Returns
+        -------
+        list
+        """
+        return data
+
+    def get_hover(self, data):
         """
         Gets the current selection of points.
 

--- a/bowtie/visual.py
+++ b/bowtie/visual.py
@@ -265,7 +265,6 @@ class Plotly(_Visual):
             init=jdumps(self.init),
         )
 
-
     ## Events
 
     def on_click(self):
@@ -279,7 +278,7 @@ class Plotly(_Visual):
             Name of event.
 
         """
-        pass
+        return self.get
 
     def on_beforehover(self):
         """Emits an event before hovering over a point.
@@ -331,7 +330,7 @@ class Plotly(_Visual):
             Name of event.
 
         """
-        pass
+        return self.get
 
     ## Commands
 

--- a/flit.ini
+++ b/flit.ini
@@ -9,6 +9,7 @@ classifiers = License :: OSI Approved :: MIT License
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
 requires=click
     eventlet
     flask


### PR DESCRIPTION
- breaks backwards compatibility so bumping to 0.2
- added a number input controller

This solves #73 in a satisfactory way for me. I want to merge this in sooner than later so I will likely bump the existing 0.2 milestone to 0.3.

To subscribe functions to events the signature is now
```
subscribe(func, event, *events)
```
You may pass additional events as variable arguments.